### PR TITLE
remove z-index, otherwise the image is not shown in <mat-dialog>

### DIFF
--- a/projects/aia-lib/src/lib/components/aia-image-annotator/aia-image-annotator.component.scss
+++ b/projects/aia-lib/src/lib/components/aia-image-annotator/aia-image-annotator.component.scss
@@ -9,10 +9,6 @@
             top: 0;
             left: 0;
 
-            &.image-canvas {
-                z-index: -1;
-            }
-
             &.merge-canvas {
                 display: none;
             }


### PR DESCRIPTION
it happens when using in a mat-dialog